### PR TITLE
Deprecate enum val

### DIFF
--- a/lib/src/fsrs_base.dart
+++ b/lib/src/fsrs_base.dart
@@ -63,22 +63,22 @@ class FSRS {
   }
 
   void _initDS(SchedulingCards s) {
-    s.again.difficulty = _initDifficulty(Rating.again.val);
-    s.again.stability = _initStability(Rating.again.val);
-    s.hard.difficulty = _initDifficulty(Rating.hard.val);
-    s.hard.stability = _initStability(Rating.hard.val);
-    s.good.difficulty = _initDifficulty(Rating.good.val);
-    s.good.stability = _initStability(Rating.good.val);
-    s.easy.difficulty = _initDifficulty(Rating.easy.val);
-    s.easy.stability = _initStability(Rating.easy.val);
+    s.again.difficulty = _initDifficulty(Rating.again.index);
+    s.again.stability = _initStability(Rating.again.index);
+    s.hard.difficulty = _initDifficulty(Rating.hard.index);
+    s.hard.stability = _initStability(Rating.hard.index);
+    s.good.difficulty = _initDifficulty(Rating.good.index);
+    s.good.stability = _initStability(Rating.good.index);
+    s.easy.difficulty = _initDifficulty(Rating.easy.index);
+    s.easy.stability = _initStability(Rating.easy.index);
   }
 
   double _initStability(int r) {
-    return max(p.w[r - 1], 0.1);
+    return max(p.w[r], 0.1);
   }
 
   double _initDifficulty(int r) {
-    return min(max(p.w[4] - p.w[5] * (r - 3), 1), 10);
+    return min(max(p.w[4] - p.w[5] * (r - 2), 1), 10);
   }
 
   double _forgettingCurve(int elapsedDays, double stability) {
@@ -91,7 +91,7 @@ class FSRS {
   }
 
   double _nextDifficulty(double d, int r) {
-    final nextD = d - p.w[6] * (r - 3);
+    final nextD = d - p.w[6] * (r - 2);
     return min(max(_meanReversion(p.w[4], nextD), 1), 10);
   }
 
@@ -121,16 +121,44 @@ class FSRS {
 
   void _nextDS(
       SchedulingCards s, double lastD, double lastS, double retrievability) {
-    s.again.difficulty = _nextDifficulty(lastD, Rating.again.val);
-    s.again.stability = _nextForgetStability(lastD, lastS, retrievability);
-    s.hard.difficulty = _nextDifficulty(lastD, Rating.hard.val);
-    s.hard.stability =
-        _nextRecallStability(lastD, lastS, retrievability, Rating.hard);
-    s.good.difficulty = _nextDifficulty(lastD, Rating.good.val);
-    s.good.stability =
-        _nextRecallStability(lastD, lastS, retrievability, Rating.good);
-    s.easy.difficulty = _nextDifficulty(lastD, Rating.easy.val);
-    s.easy.stability =
-        _nextRecallStability(lastD, lastS, retrievability, Rating.easy);
+    s.again.difficulty = _nextDifficulty(
+      lastD,
+      Rating.again.index,
+    );
+    s.again.stability = _nextForgetStability(
+      lastD,
+      lastS,
+      retrievability,
+    );
+    s.hard.difficulty = _nextDifficulty(
+      lastD,
+      Rating.hard.index,
+    );
+    s.hard.stability = _nextRecallStability(
+      lastD,
+      lastS,
+      retrievability,
+      Rating.hard,
+    );
+    s.good.difficulty = _nextDifficulty(
+      lastD,
+      Rating.good.index,
+    );
+    s.good.stability = _nextRecallStability(
+      lastD,
+      lastS,
+      retrievability,
+      Rating.good,
+    );
+    s.easy.difficulty = _nextDifficulty(
+      lastD,
+      Rating.easy.index,
+    );
+    s.easy.stability = _nextRecallStability(
+      lastD,
+      lastS,
+      retrievability,
+      Rating.easy,
+    );
   }
 }

--- a/lib/src/models.dart
+++ b/lib/src/models.dart
@@ -14,6 +14,9 @@ enum State {
 
   const State(this.val);
 
+  /// Deprecated. Duplicate of [index].
+  /// Use [index] instead.
+  @Deprecated('Use [index] instead')
   final int val;
 }
 
@@ -25,6 +28,9 @@ enum Rating {
 
   const Rating(this.val);
 
+  /// Deprecated. Duplicate of [index].
+  /// Use [index] + 1 instead.
+  @Deprecated('Use [index] + 1 instead')
   final int val;
 }
 

--- a/lib/src/models.freezed.dart
+++ b/lib/src/models.freezed.dart
@@ -100,8 +100,13 @@ mixin _$Card {
     required TResult orElse(),
   }) =>
       throw _privateConstructorUsedError;
+
+  /// Serializes this Card to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of Card
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $CardCopyWith<Card> get copyWith => throw _privateConstructorUsedError;
 }
 
@@ -132,6 +137,8 @@ class _$CardCopyWithImpl<$Res, $Val extends Card>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of Card
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -212,6 +219,8 @@ class __$$CardImplCopyWithImpl<$Res>
   __$$CardImplCopyWithImpl(_$CardImpl _value, $Res Function(_$CardImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of Card
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -313,7 +322,9 @@ class _$CardImpl extends _Card {
     return 'Card.def(due: $due, lastReview: $lastReview, stability: $stability, difficulty: $difficulty, elapsedDays: $elapsedDays, scheduledDays: $scheduledDays, reps: $reps, lapses: $lapses, state: $state)';
   }
 
-  @JsonKey(ignore: true)
+  /// Create a copy of Card
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$CardImplCopyWith<_$CardImpl> get copyWith =>
@@ -456,8 +467,11 @@ abstract class _Card extends Card {
   @override
   State get state;
   set state(State value);
+
+  /// Create a copy of Card
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$CardImplCopyWith<_$CardImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }


### PR DESCRIPTION
Both `State.val` and `Rating.val` are unnecessary. Dart already has `Enum.index`, this commit marks the unnecessary properties to be deprecated in future major version release.